### PR TITLE
jax-finufft v1.3.0rc1

### DIFF
--- a/.ci_support/linux_64_cuda_compiler_version13.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version13.0python3.11.____cpython.yaml
@@ -1,0 +1,34 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fftw:
+- '3'
+nccl:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_cuda_compiler_version13.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version13.0python3.12.____cpython.yaml
@@ -1,0 +1,34 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fftw:
+- '3'
+nccl:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_cuda_compiler_version13.0python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version13.0python3.13.____cp313.yaml
@@ -1,0 +1,34 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fftw:
+- '3'
+nccl:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- linux-64
+zip_keys:
+- - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/.ci_support/linux_64_cuda_compiler_version13.0python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version13.0python3.14.____cp314.yaml
@@ -1,0 +1,34 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fftw:
+- '3'
+nccl:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- linux-64
+zip_keys:
+- - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,2 @@
-c_stdlib_version:          # [osx and x86_64]
-- '10.14'                  # [osx and x86_64]
-MACOSX_SDK_VERSION:        # [osx and x86_64]
-- '10.14'                  # [osx and x86_64]
+channel_targets:
+  - conda-forge jax-finufft_rc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jax-finufft" %}
-{% set version = "1.2.0" %}
+{% set version = "1.3.0rc1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/j/jax-finufft/jax_finufft-{{ version }}.tar.gz
-  sha256: e85fc8c56a3ec3977db3e0348b9ba28128227a4a4e2096ec6261fce2af42b65b
+  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 build:
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
-  skip: true  # [win or py<310 or (osx and x86_64)]
+  skip: true  # [win or py<311 or (osx and x86_64)]
   script_env:
     # Turn off "-march=native"
     - SKBUILD_CMAKE_DEFINE="FINUFFT_ARCH_FLAGS="                                                       # [cuda_compiler_version == "None"]
@@ -51,7 +51,7 @@ requirements:
     - libgomp  # [linux]
   run:
     - python
-    - jax >=0.5.0,<0.8
+    - jax >=0.5.0
     - pydantic >=2
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
   script_env:
     # Turn off "-march=native"
     - SKBUILD_CMAKE_DEFINE="FINUFFT_ARCH_FLAGS="                                                       # [cuda_compiler_version == "None"]
-    - SKBUILD_CMAKE_DEFINE="JAX_FINUFFT_USE_CUDA=ON;CMAKE_CUDA_ARCHITECTURES=all;FINUFFT_ARCH_FLAGS="  # [cuda_compiler_version != "None"]
+    - SKBUILD_CMAKE_DEFINE="JAX_FINUFFT_USE_CUDA=ON;CMAKE_CUDA_ARCHITECTURES=all-major;FINUFFT_ARCH_FLAGS="  # [cuda_compiler_version != "None"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version == "None"]
 
@@ -34,12 +34,12 @@ requirements:
     - make
   host:
     - nccl                                      # [cuda_compiler_version != "None"]
-    - cuda-cupti-dev                            # [(cuda_compiler_version or "").startswith("12")]
-    - cuda-cudart-dev                           # [(cuda_compiler_version or "").startswith("12")]
-    - cuda-nvml-dev                             # [(cuda_compiler_version or "").startswith("12")]
-    - cuda-nvtx-dev                             # [(cuda_compiler_version or "").startswith("12")]
-    - libcufft-dev                              # [(cuda_compiler_version or "").startswith("12")]
-    - libcufft-static                           # [(cuda_compiler_version or "").startswith("12")]
+    - cuda-cupti-dev                            # [cuda_compiler_version != "None"]
+    - cuda-cudart-dev                           # [cuda_compiler_version != "None"]
+    - cuda-nvml-dev                             # [cuda_compiler_version != "None"]
+    - cuda-nvtx-dev                             # [cuda_compiler_version != "None"]
+    - libcufft-dev                              # [cuda_compiler_version != "None"]
+    - libcufft-static                           # [cuda_compiler_version != "None"]
     - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
     - python
     - scikit-build-core


### PR DESCRIPTION
Attempting a manual rc release and CUDA 13 migration, since we need the new version to do the CUDA 13 migration, but we can't do the automatic migration in an rc branch.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
